### PR TITLE
Prepare release of version 3.6.4/stable

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function set_default_properties () {
+    mkdir "${SNAP_COMMON}"/data
+    mkdir "${SNAP_COMMON}"/log
+    mkdir "${SNAP_COMMON}"/logs
+
+    cp "${SNAP}"/conf/zoo_sample.cfg "${SNAP_COMMON}"/zoo.cfg
+    cp "${SNAP}"/conf/log4j.properties "${SNAP_COMMON}"/log4j.properties
+    cp -rL "${SNAP}"/usr/lib/jvm "${SNAP_COMMON}"
+
+    chmod -R 770 ${SNAP_COMMON}
+    chown -R snap_daemon ${SNAP_COMMON}
+    chgrp root ${SNAP_COMMON}
+}
+
+set_default_properties

--- a/snap/local/with_config.sh
+++ b/snap/local/with_config.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-export JAVA_HOME="${SNAP_COMMON}/jvm/java-8-openjdk-amd64/jre"
-export ZOO_LOG_DIR="${SNAP_COMMON}/logs"
-export ZOOCFGDIR="${SNAP_COMMON}"
-
 "${SNAP}"/usr/bin/setpriv \
     --clear-groups \
     --reuid snap_daemon \

--- a/snap/local/with_config.sh
+++ b/snap/local/with_config.sh
@@ -2,20 +2,9 @@
 
 set -e
 
-export CONFIG_FILE="${SNAP_COMMON}/zoo.cfg"
-if [ ! -f "${CONFIG_FILE}" ]; then
-	echo "custom configuration file ${CONFIG_FILE} does not exist."
-	echo "copying default config to ${CONFIG_FILE}"
-	cp $SNAP/conf/zoo_sample.cfg $CONFIG_FILE
-fi
-
-export PATH="${SNAP}/usr/lib/jvm/default-java/bin:${PATH}"
-export JAVA_HOME="${SNAP}/usr/lib/jvm/java-8-openjdk-amd64/jre"
+export JAVA_HOME="${SNAP_COMMON}/jvm/java-8-openjdk-amd64/jre"
 export ZOO_LOG_DIR="${SNAP_COMMON}/logs"
 export ZOOCFGDIR="${SNAP_COMMON}"
-
-cp -r "${SNAP}/conf/log4j.properties" ${SNAP_COMMON}
-
 
 "${SNAP}"/usr/bin/setpriv \
     --clear-groups \

--- a/snap/local/with_config.sh
+++ b/snap/local/with_config.sh
@@ -16,4 +16,9 @@ export ZOOCFGDIR="${SNAP_COMMON}"
 
 cp -r "${SNAP}/conf/log4j.properties" ${SNAP_COMMON}
 
-"${SNAP}/${1}" --config "${SNAP_COMMON}" $2
+
+"${SNAP}"/usr/bin/setpriv \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon -- \
+    "${SNAP}/${1}" --config "${SNAP_COMMON}" $2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 base: core22
-version: '3.6.3'
+version: '3.6.4'
 summary: Apache Zookeeper in a snap.
 description: |
   ZooKeeper is a centralized service for maintaining configuration 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,9 @@ description: |
 grade: stable
 confinement: strict
 
+system-usernames:
+  snap_daemon: shared
+
 apps:
   init:
     command: with_config.sh bin/zkServer-initialize.sh
@@ -17,7 +20,10 @@ apps:
     command: with_config.sh bin/zkCli.sh
   daemon:
     command: with_config.sh bin/zkServer.sh start
-    plugs: [network, network-bind, removable-media]
+    plugs:
+      - network
+      - network-bind
+      - removable-media
     install-mode: disable
     daemon: forking
     stop-command: with_config.sh bin/zkServer.sh stop
@@ -30,6 +36,7 @@ parts:
     source: https://dlcdn.apache.org/zookeeper/zookeeper-${SNAPCRAFT_PROJECT_VERSION}/apache-zookeeper-${SNAPCRAFT_PROJECT_VERSION}-bin.tar.gz
     stage-packages:
     - openjdk-8-jre-headless
+    - util-linux
     override-build: |-
       snapcraftctl build
       sed -i "s:dataDir=/tmp/zookeeper:dataDir=/var/snap/zookeeper/common:g" conf/zoo_sample.cfg

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,11 @@ hooks:
       - network
       - network-bind
 
+environment:
+  JAVA_HOME: ${SNAP_COMMON}/jvm/java-8-openjdk-amd64/jre
+  ZOO_LOG_DIR: ${SNAP_COMMON}/logs
+  ZOOCFGDIR: ${SNAP_COMMON}
+
 apps:
   init:
     command: with_config.sh bin/zkServer-initialize.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,12 @@ confinement: strict
 system-usernames:
   snap_daemon: shared
 
+hooks:
+  install:
+    plugs:
+      - network
+      - network-bind
+
 apps:
   init:
     command: with_config.sh bin/zkServer-initialize.sh


### PR DESCRIPTION
NOTE - This PR will not get merged due to branch structure (will address in a separate PR), this diff is just for review and feedback purposes

## Changes Made
##### `chore: add install hook for cp jvm+conf files and perms`
- New install hook, on `snap install`:
    - creates necessary directories `data`, `log` and `logs` to `$SNAP_COMMON`
    - copies java files to `$SNAP_COMMON/jvm`, following symbolic links to `etc/java-8-openjdk/`
    - sets `snap_daemon` as owner and `root` as group of `$SNAP_COMMON` with `rwx`, no permissions for other users
##### `chore: use snap_daemon_user`
- Ensures snap apps are ran as non-root UID






