### PR TITLE
Add logs slot to support integrating with grafana-agent over contents interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,8 +32,17 @@ apps:
       - network
       - network-bind
       - removable-media
+    slots:
+      - logs
     install-mode: disable
     daemon: simple
+
+
+slots:
+  logs:
+    interface: content
+    target: ${SNAP_COMMON}/logs
+
 
 parts:
   zookeeper:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,10 @@ apps:
 slots:
   logs:
     interface: content
-    target: ${SNAP_COMMON}/logs
+    content: logs
+    source:
+      read: 
+        - $SNAP_COMMON/logs
 
 
 parts:


### PR DESCRIPTION
Title says it all. 

Tested by installing this snap on a zookeeper charm on a lxd model, relating with a grafana-agent charm and manually connecting the snaps.